### PR TITLE
Minor improvement about CC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CC := clang
+CC = cc
 CFLAGS = -O2 -g
 LDFLAGS = -lssl -lcrypto -lz
 COMPILE = $(CC) $(CFLAGS)


### PR DESCRIPTION
* Simply use `=` instaed of `:=` to assign value.
* Use `cc` as value to make compatible with GCC based architecture.