### PR TITLE
Respect ports openssl variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,14 @@
 PROG= gitup
 SRCS= gitup.c
 
+.if !empty(OPENSSLINC)
+CFLAGS+=	-I${OPENSSLINC}
+.endif
+
+.if !empty(OPENSSLLIB)
+LDFLAGS+=	-L${OPENSSLLIB}
+.endif
+
 LDADD= -lssl -lz -lcrypto -lprivateucl
 
 WARNS= 6


### PR DESCRIPTION
Ports infrastructure allows users to use different implementation of
openssl other than the one distributed as part of base system.  Respect
OPENSSLINC and OPENSSLLIB when they are defined