### PR TITLE
gitup.conf, gitup.conf.sample: releng/13.2, stable/14

### DIFF
--- a/gitup.conf
+++ b/gitup.conf
@@ -32,7 +32,7 @@
 
 	"release" : {
 		"repository_path"  : "/src.git",
-		"branch"           : "releng/11.4",
+		"branch"           : "releng/13.2",
 		"target_directory" : "/usr/src",
 		"ignores"          : [
 			"sys/[^\/]+/conf",
@@ -41,7 +41,7 @@
 
 	"stable" : {
 		"repository_path"  : "/src.git",
-		"branch"           : "stable/12",
+		"branch"           : "stable/14",
 		"target_directory" : "/usr/src",
 		"ignores"          : [
 			"sys/[^\/]+/conf",


### PR DESCRIPTION
`releng/11.4` is end of life, so update the `release` section of configuration files.

Whilst here: update the `stable` section. 